### PR TITLE
Clean servers utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ coverage.xml
 *.mo
 
 # Mr Developer
+env
+.DS_Store
 .mr.developer.cfg
 .project
 .pydevproject

--- a/app/controllers/admin.py
+++ b/app/controllers/admin.py
@@ -305,7 +305,6 @@ class AdminToolsView(FlaskView):
 
             servers = Server.query.filter_by(status='active', type='temp', mumble_host=hostname).all()
             expired = [s.mumble_instance for s in servers if s.is_expired]  # Filter servers if it should be expired.
-            print expired
 
             for s in servers:
                 s.status = 'expired'
@@ -313,7 +312,6 @@ class AdminToolsView(FlaskView):
 
             try:
                 db.session.commit()
-                print expired
                 murmur.cleanup_expired_servers(location, expired)
                 return redirect('/admin/tools/')
             except:

--- a/app/forms.py
+++ b/app/forms.py
@@ -146,6 +146,13 @@ class SuperuserPasswordForm(Form):
     instance = IntegerField('instance')
 
 
+class CleanupExpiredServersForm(Form):
+    _server_locations = build_hosts_list()
+    location = SelectField('location',
+                           validators=[DataRequired()],
+                           choices=_server_locations)
+
+
 class ContactForm(Form):
     subject = TextField('subject', validators=[DataRequired('Subject is required.')])
     email = TextField('email', validators=[Email('Invalid email address.'), DataRequired('Email is required.')])

--- a/app/models.py
+++ b/app/models.py
@@ -27,6 +27,12 @@ class Server(db.Model):
     def expiration(self):
         return self.created_date + datetime.timedelta(hours=self.duration)
 
+    @hybrid_property
+    def is_expired(self):
+        now = datetime.datetime.utcnow()
+        exp = self.created_date + datetime.timedelta(hours=self.duration)
+        return now > exp
+
     def __repr__(self):
         return '<Server %r>' % self.id
 

--- a/app/murmur.py
+++ b/app/murmur.py
@@ -291,16 +291,28 @@ def set_superuser_password(location, password, instance_id):
     return None
 
 
-def cleanup_expired_servers(location):
+def cleanup_expired_servers(location, expired_ids):
     """
     Cleans up expired servers.
     @param location: location from config
+    @param expired_ids: list of mumble_instance IDs to be expired.
     @return: None
     """
     host = get_host_by_location(location)['uri']
     auth = get_murmur_credentials(location)
+    expired_ids = ','.join(str(x) for x in expired_ids)
+    print expired_ids
 
-    return
+    try:
+        r = requests.delete("%s/servers/delete?id=%s" % (host, expired_ids), auth=HTTPDigestAuth(auth['username'],
+                                                                                      auth['password']))
+        if r.status_code == 200:
+            return r.json()
+    except requests.exceptions.ConnectionError as e:
+        import traceback
+        traceback.print_exc()
+        return None
+    return None
 
 
 def stop_server(host, instance_id):
@@ -311,6 +323,7 @@ def stop_server(host, instance_id):
     @return:
     """
     return
+
 
 def start_server(host, instance_id):
     """
@@ -324,6 +337,7 @@ def start_server(host, instance_id):
 ##
 ## Utilities for interfacing with murmur servers
 ##
+
 
 def find_available_port(location):
     """

--- a/app/murmur.py
+++ b/app/murmur.py
@@ -291,6 +291,18 @@ def set_superuser_password(location, password, instance_id):
     return None
 
 
+def cleanup_expired_servers(location):
+    """
+    Cleans up expired servers.
+    @param location: location from config
+    @return: None
+    """
+    host = get_host_by_location(location)['uri']
+    auth = get_murmur_credentials(location)
+
+    return
+
+
 def stop_server(host, instance_id):
     """
     Stops a server by host and id.

--- a/app/templates/admin/tools.html
+++ b/app/templates/admin/tools.html
@@ -39,6 +39,15 @@
         <button type="submit" class="pure-button pure-button-primary">Send</button>
       </fieldset>
     </form>
+
+    <form action="cleanup-expired-servers" method="post" name="role" class="pure-form">
+        {{ cleanup_form.csrf_token }}
+        <fieldset>
+            <legend>Cleans up expired servers.</legend>
+            {{ cleanup_form.location }}
+            <button type="submit" class="pure-button pure-button-primary">Clean</button>
+        </fieldset>
+    </form>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
When celery workers fail (for whatever reasons), this can leave many stale servers that should have been expired. So instead of shutting these down one-by-one manually for the last year or so, I wrote an admin utility to clean these up.